### PR TITLE
Improved support for Windows, updates to dataset.meta_to_json()

### DIFF
--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -780,6 +780,18 @@ class DataSet(object):
         -------
         None
         """
+
+        class NumpyEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, np.integer):
+                    return int(obj)
+                elif isinstance(obj, np.floating):
+                    return float(obj)
+                elif isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                else:
+                    return super(NumpyEncoder, self).default(obj)
+
         meta = self._meta
         if key: k = '@{}'.format(key)
         col = {'columns': 'columns{}'.format(k if key else ''),
@@ -803,7 +815,7 @@ class DataSet(object):
         ds_path = '../' if self.path == '/' else self.path
         path = os.path.join(ds_path, ''.join([self.name, '_', name, '.json']))
         with open(path, 'w') as file:
-            json.dump(obj, file)
+            json.dump(obj, file, cls=NumpyEncoder)
         print('create: {}'.format(path))
         return None
 

--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -801,7 +801,7 @@ class DataSet(object):
             name = '{}{}'.format(collection, '_{}'.format(key.split('.')[0])
                                  if key else '')
         ds_path = '../' if self.path == '/' else self.path
-        path = os.path.join(ds_path, ''.json([self.name, '_', name, '.json']))
+        path = os.path.join(ds_path, ''.join([self.name, '_', name, '.json']))
         with open(path, 'w') as file:
             json.dump(obj, file)
         print('create: {}'.format(path))

--- a/savReaderWriter/generic.py
+++ b/savReaderWriter/generic.py
@@ -130,7 +130,7 @@ class Generic(object):
     def errcheck(self, res, func, args):
         """This function checks for errors during the execution of
         function <func>"""
-        if not res:
+        if res == -1:
             msg = "Error performing %r operation on file %r."
             raise IOError(msg % (func.__name__, self.savFileName))
         return res
@@ -187,7 +187,7 @@ class Generic(object):
             fdopen = self.libc._fdopen  # Windows
         except AttributeError:
             fdopen = self.libc.fdopen   # Linux and others
-        fdopen.argtypes, fdopen.restype = [c_int, c_char_p], c_void_p
+        fdopen.argtypes, fdopen.restype = [c_int, c_char_p], c_int
         fdopen.errcheck = self.errcheck
         mode_ = b"wb" if mode == b"cp" else mode
         with open(savFileName, mode_.decode("utf-8")) as f:

--- a/savReaderWriter/generic.py
+++ b/savReaderWriter/generic.py
@@ -12,6 +12,7 @@ import math
 import locale
 import encodings
 import collections
+import traceback
 
 from savReaderWriter import *
 from py3k import *
@@ -27,7 +28,10 @@ class Generic(object):
         be set once"""
         locale.setlocale(locale.LC_ALL, "")
         self.savFileName = savFileName
-        self.libc = cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == 'nt':
+            self.libc = cdll.LoadLibrary('msvcrt')
+        else:
+            self.libc = cdll.LoadLibrary(ctypes.util.find_library('c'))
         self.spssio = self.loadLibrary()
 
         self.wholeCaseIn = self.spssio.spssWholeCaseIn
@@ -383,6 +387,8 @@ class Generic(object):
     def ioLocale(self, localeName=""):
         if not localeName:
             localeName = ".".join(locale.getlocale())
+        if os.name == 'nt' and localeName == 'en_US.UTF-8':
+            localeName = 'english'
         func = self.spssio.spssSetLocale
         func.restype = c_char_p
         self.setLocale = func(c_int(locale.LC_ALL), c_char_py3k(localeName))

--- a/savReaderWriter/header.py
+++ b/savReaderWriter/header.py
@@ -30,7 +30,10 @@ class Header(Generic):
         """Constructor"""
         super(Header, self).__init__(savFileName, ioUtf8, ioLocale)
         self.spssio = self.loadLibrary()
-        self.libc = cdll.LoadLibrary(ctypes.util.find_library("c"))
+        if os.name == 'nt':
+            self.libc = cdll.LoadLibrary('msvcrt')
+        else:
+            self.libc = cdll.LoadLibrary(ctypes.util.find_library('c'))
         self.fh = super(Header, self).openSavFile(savFileName, mode,
                                                   refSavFileName)
         self.varNames, self.varTypes = self.varNamesTypes


### PR DESCRIPTION
- Fixed ```TypeError: LoadLibrary() argument 1 must be str, not None``` when using ```read_spss()``` and ```write_spss()``` on Windows. Force msvcrt as libc if ```os.name == 'nt'```.
- Fixed ```TypeError: Object of type int64 is not JSON serializable``` when using ```dataset.meta_to_json()```. Integers were being stored as numpy data type. Solution from https://stackoverflow.com/a/57915246.
- Fixed ```AttributeError: 'str' object has no attribute 'json'``` when using ```dataset.meta_to_json()```. When setting the json ```path```, ```''.json()``` should be ```''.join()```.
- Fixed issue with invalid ioLocale for English on Windows
- Fixed issue with errcheck() on fdopen()