### PR TITLE
Use new crosstab method from python2 version.

### DIFF
--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -40,6 +40,8 @@ from quantipy.core.tools.dp.prep import (
 
 from .cache import Cache
 
+from quantipy.sandbox.sandbox import ChainManager
+
 import copy as org_copy
 import json
 import warnings
@@ -1849,20 +1851,140 @@ class DataSet(object):
         else:
             return [parent for parent in self._meta['columns'][name]['parent']]
 
-    def crosstab(self, x, y=None, w=None, pct=False, decimals=1, text=True,
-                 rules=False, xtotal=False, f=None):
+    @modify(to_list=['x', 'y', 'ci', 'sig_level'])
+    @verify(variables={'x': 'both', 'y': 'both_nested', 'w': 'columns'})
+    def crosstab(self, x, y=[], w=None, f=None, ci='counts', stats=False,
+                 sig_level=None, rules=False, decimals=1, xtotal=False,
+                 painted=True):
         """
+        Return a well formated crosstab. (New version)
+        Parameters
+        ----------
+        x: str/ list of str
+            Name(s) of the downbreak variable(s).
+        y: str/ list of str
+            Name(s) of the crossbreak variable(s).
+        w: str, default None
+            Name of a weight variable.
+        f: str or logic
+            The name of a string variable or a logic statements which can be
+            used in DataSet.take().
+        ci: str/ list of str {'c%', 'counts'}, default 'counts'
+            Defines the output cellitem.
+        stats: bool, default False
+            Add std stats to the output dataframe (mean, median, stddev,
+            quartiles).
+        sig_level: float
+            Add a sigtest (only one level provided) to the output dataframe.
+        rules: bool, default False
+            Apply given rules from the meta object to the output dataframe.
+        decimals: int, default 1
+            Rounding for the output dataframe.
+        xtotal: bool, default False
+            If True, the first column of the returned dataframe will be the
+            regular frequency of the x column.
+        painted: bool, default True
+            Add texts from the meta to the index and columns.
         """
-        meta, data = self.split()
-        if f:
-            slicer = self.take(f)
-            data = data.copy().iloc[slicer]
-        y = '@' if not y else y
-        get = 'count' if not pct else 'normalize'
-        show = 'values' if not text else 'text'
-        return ct(org_copy.deepcopy(meta), data, x=x, y=y, get=get, weight=w,
-                  show=show, rules=rules, xtotal=xtotal, decimals=decimals)
+        def _rounding(x, dec):
+            try:
+                return np.round(x, decimals=dec)
+            except:
+                return x
+        #######################################################################
+        # prepare stack
+        #######################################################################
+        if isinstance(f, str) or not f:
+            idx = self.manifest_filter(f)
+        else:
+            idx = self.take(f)
+        data = self._data.copy().iloc[idx]
+        stack = qp.Stack(name='ct', add_data={'ct': (data, self._meta)})
+        if xtotal or not y:
+            y = ['@'] + self.unroll(y)
+        else:
+            y = self.unroll(y)
+        test_y =  [yk for yk in y if yk != '@']
+        # views = ['cbase', 'rbase']
+        views = ['cbase']
+        for i in ci:
+            if not i in ['counts', 'c%']:
+                raise ValueError("Provides only counts and c%")
+            else:
+                views.append(i)
+        stack.add_link('ct', x=x, y=y, views=views, weights=w)
+        if stats:
+            stats = ['mean', 'median', 'stddev', 'lower_q', 'upper_q']
+            options = {
+                'stats': '',
+                'axis': 'x'}
+            view = qp.ViewMapper()
+            view.make_template('descriptives')
+            for stat in stats:
+                options['stats'] = stat
+                view.add_method('stat', kwargs=options)
+                stack.add_link('ct', x=x, y=y, views=view, weights=w)
+        if sig_level and test_y:
+            view = qp.ViewMapper().make_template(
+                method='coltests',
+                iterators={
+                    'metric': ['props', 'means'],
+                    'mimic': ['Dim'],
+                    'level': sig_level})
+            view.add_method(
+                'significance',
+                kwargs = {
+                    'flag_bases': [30, 100],
+                    'test_total': None,
+                    'groups': 'Tests'})
+            stack.add_link('ct', x=x, y=y, views=view, weights=w)
+        #######################################################################
+        # prepare ViewManager
+        #######################################################################
+        vm = qp.ViewManager(stack)
+        if ci == ['counts']:
+            cellitems = 'counts'
+        elif ci == ['c%']:
+            cellitems = 'colpct'
+        elif 'counts' in ci and 'c%' in ci:
+            cellitems = 'counts_colpct'
+        vm.get_views(
+            data_key='ct',
+            filter_key='no_filter',
+            weight=w,
+            freqs=True,
+            stats=stats,
+            tests=sig_level,
+            cell_items=cellitems,
+            bases='both')
+        vm.set_bases('both', False, False, 'both')
+        #######################################################################
+        # prepare ChainManager
+        #######################################################################
+        cm = ChainManager(stack)
+        cm.get(
+            data_key   = 'ct',
+            filter_key = 'no_filter',
+            x_keys     = x,
+            y_keys     = y,
+            views      = vm.views,
+            orient     = 'x',
+            prioritize = True,
+            rules      = rules,
+            rules_weight = w or '',
+            folder     = 'ct')
 
+        if painted:
+            cm.paint_all(totalize=True)
+
+        dfs = []
+        for chain in cm['ct']:
+            df = chain.dataframe
+            dfs.append(df)
+        all_df = pd.concat(dfs)
+        for c in df.columns:
+            all_df[c] = all_df[c].apply(lambda x: _rounding(x, decimals))
+        return all_df
 
     def data(self):
         """

--- a/quantipy/core/view_generators/view_specs.py
+++ b/quantipy/core/view_generators/view_specs.py
@@ -155,9 +155,9 @@ class ViewManager(object):
             self.group(switch=True)
         return self
 
-    def set_bases(self, base='w', gross=False, effective=False,
-                  order=['base', 'gross', 'effective'], uw_pos='before',
-                  sticky_gross=False):
+    def set_bases(self, base='w', gross=False, effective=False, rbase=False,
+                    order=['base', 'gross', 'rbase', 'effective'],
+                    uw_pos='before', sticky_gross=False):
         """
         Set the base (sample size) view presentation.
 
@@ -172,8 +172,11 @@ class ViewManager(object):
         effective : {'w', 'uw', 'both'}, default False
             Show the *weighted* or *unweighted* version of the effective base
             or *both*.
-        order : list of elements 'base', 'gross', 'effective',
-                default ['base', 'gross', 'effective']
+        rbase : {'w', 'uw', 'both'}, default False
+            Show the *weighted* or *unweighted* version of the row base or
+            *both*.
+        order : list of elements 'base', 'gross', 'effective', 'rbase'
+                default ['base', 'gross', 'rbase' 'effective']
             Set the order in that regular, gross and effective bases should
             appear.
         uw_pos : {'after', 'before'}, default 'after'
@@ -199,7 +202,8 @@ class ViewManager(object):
             if base: base = 'uw'
             if gross: gross = 'uw'
             if effective: effective = 'uw'
-        valid_order_items = ['base', 'gross', 'effective']
+            if rbase: rbase = 'uw'
+        valid_order_items = ['base', 'gross', 'rbase', 'effective']
         if not all(b in valid_order_items for b in order):
             err = "Items in 'order' must be one of: {}!".format(valid_order_items)
             raise ValueError(err)
@@ -207,16 +211,20 @@ class ViewManager(object):
         base_vk = 'x|f|x:||{}|cbase'
         gross_vk = 'x|f|x:||{}|cbase_gross'
         effective_vk = 'x|f|x:||{}|ebase'
+        rbase_vk = 'x|f|:y||{}|rbase'
         uw_base_vk = base_vk.format('')
         uw_gross_vk = gross_vk.format('')
         uw_effective_vk = effective_vk.format('')
+        uw_rbase_vk = rbase_vk.format('')
         if self.weighted:
             w_base_vk = base_vk.format(self.weighted)
             w_gross_vk = gross_vk.format(self.weighted)
             w_effective_vk = effective_vk.format(self.weighted)
+            w_rbase_vk = rbase_vk.format(self.weighted)
         else:
-            w_base_vk = w_gross_vk = w_effective_vk = None
+            w_base_vk = w_gross_vk = w_effective_vk = w_rbase_vk = None
         base_dict = {'base': [base, uw_base_vk, w_base_vk],
+                     'rbase': [rbase, uw_rbase_vk, w_rbase_vk],
                      'gross': [gross, uw_gross_vk, w_gross_vk],
                      'effective': [effective, uw_effective_vk, w_effective_vk]}
         # assembling all base types...

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
     INSTALL_REQUIRES = version_libs(libs, precisions, versions)
 
 setup(name='quantipy3',
-      version='0.2.3',
+      version='0.2.4',
       author='Geir Freysson',
       author_email='geir@datasmoothie.com',
       packages=find_packages(exclude=['tests']),

--- a/tests/test_confirmit_reader.py
+++ b/tests/test_confirmit_reader.py
@@ -45,7 +45,8 @@ def test_single_type(confirmit_dataset):
     print(confirmit_dataset.meta('q21'))
     assert confirmit_dataset.crosstab('q21').shape == (5,1)
     print(confirmit_dataset.crosstab('q39', 'q21'))
-    assert confirmit_dataset.crosstab('q39', 'q21').shape == (3,5)
+    assert confirmit_dataset.crosstab('q39', 'q21').shape == (3,4)
+    
     assert confirmit_dataset.meta()['columns']['q39'] == json.loads("""
     {"name": "q39",
     "parent": {},
@@ -99,7 +100,7 @@ def test_delimited_set_type(confirmit_dataset):
         "text": {"en": "multi - default options"}}""")
     assert confirmit_dataset.crosstab('q1').shape == (4,1)
     print(confirmit_dataset.crosstab('q1', 'q22'))
-    assert confirmit_dataset.crosstab('q1', 'q22').shape == (4,5)
+    assert confirmit_dataset.crosstab('q1', 'q22').shape == (4,4)
 
 def test_number_type(confirmit_dataset):
     print(confirmit_dataset.meta('q73'))
@@ -111,11 +112,11 @@ def test_number_type(confirmit_dataset):
     "text": {"en": "open - numeric"}}
     """)
     assert confirmit_dataset.crosstab('q73').shape == (71, 1)
-    assert confirmit_dataset.crosstab('q73', 'q39').shape == (71, 3)
+    assert confirmit_dataset.crosstab('q73', 'q39').shape == (71, 2)
 
 def test_array_type(confirmit_dataset):
     print(confirmit_dataset.meta()['columns']['q5_1'])
-    assert confirmit_dataset.crosstab('q5_1', 'q39').shape == (52, 3)
+    assert confirmit_dataset.crosstab('q5_1', 'q39').shape == (52, 2)
     assert confirmit_dataset.meta()['masks']['q5'] == json.loads("""
     {"name": "q5",
     "parent": {},
@@ -145,7 +146,7 @@ def test_array_type(confirmit_dataset):
 
 def test_rating_type(confirmit_dataset):
     print(confirmit_dataset.meta()['columns']['q14_1'])
-    assert confirmit_dataset.crosstab('q14_1', 'q39').shape == (4, 3)
+    assert confirmit_dataset.crosstab('q14_1', 'q39').shape == (4, 2)
     print(confirmit_dataset.meta()['masks']['q14'])
     assert confirmit_dataset.meta()['masks']['q14'] == json.loads("""
     {
@@ -187,7 +188,7 @@ def test_rating_type(confirmit_dataset):
 
 def test_ranking_type(confirmit_dataset):
     print(confirmit_dataset.meta()['columns']['q2_1'])
-    assert confirmit_dataset.crosstab('q2_1', 'q39').shape == (11, 3)
+    assert confirmit_dataset.crosstab('q2_1', 'q39').shape == (11, 2)
     print(confirmit_dataset.meta()['masks']['q2'])
     assert confirmit_dataset.meta()['masks']['q2'] == json.loads("""
     {
@@ -263,7 +264,7 @@ def test_ranking_type(confirmit_dataset):
 def test_multigrid_type(confirmit_dataset):
     print(confirmit_dataset.meta()['masks']['g56'])
     print(confirmit_dataset.crosstab('g56_1'))
-    assert confirmit_dataset.crosstab('g56_1', 'q39').shape == (3, 3)
+    assert confirmit_dataset.crosstab('g56_1', 'q39').shape == (3, 2)
     print(confirmit_dataset.meta()['masks']['g56'])
     assert confirmit_dataset.meta()['masks']['g56'] == json.loads("""
     {
@@ -305,7 +306,7 @@ def test_read_from_api():
     print(dataset_from_api.meta('q21'))
     assert dataset_from_api.crosstab('q21').shape == (6,1)
     print(dataset_from_api.crosstab('q39', 'q21'))
-    assert dataset_from_api.crosstab('q39', 'q21').shape == (3,6)
+    assert dataset_from_api.crosstab('q39', 'q21').shape == (3,5)
     assert dataset_from_api.meta()['columns']['q39'] == json.loads("""
     {"name": "q39",
     "parent": {},

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -582,7 +582,7 @@ class TestDataSet(unittest.TestCase):
         dataset = self._get_dataset()
         dataset.uncode('q8',{1: 1, 2:2, 5:5}, 'q8', intersect={'gender':1})
         dataset.uncode('q8',{3: 3, 4:4, 98:98}, 'q8', intersect={'gender':2})
-        df = dataset.crosstab('q8', 'gender')
+        df = dataset.crosstab('q8', 'gender', xtotal=True)
         result = [[ 1797.,   810.,   987.],
                   [  476.,     0.,   476.],
                   [  104.,     0.,   104.],
@@ -801,6 +801,16 @@ class TestDataSet(unittest.TestCase):
         text = {'en-GB': 'What is your main fitness activity?',
                 'x edits': {'en-GB': 'edit'}, 'y edits':{'en-GB': 'edit'}}
         dataset.set_variable_text('q1', 'edit', 'en-GB', ['x', 'y'])
+
+    def test_crosstab2(self):
+        dataset = self._get_dataset()
+        result = dataset.crosstab('q1', 'gender')
+        with_sigdiff = dataset.crosstab('q1', 'q4 > gender', 
+                                        ci=['counts', 'c%'], 
+                                        sig_level=0.95,
+                                        painted=True)
+        assert result.shape == (13,2)
+        assert with_sigdiff.shape == (37,4)
 
     def test_crosstab(self):
         x = 'q14r01c01'


### PR DESCRIPTION
This pull request pulls a new implementation of the dataset.crosstab method from 
[a branch](https://github.com/Quantipy/quantipy/tree/i1216_dataset_crosstab)  in the python2 version of Quantipy.

This new version supports
- nested crosstabs
- significance tests
- showing bases, counts, percentages and stats in the same table 