### PR TITLE
Fix bug where sig-diff wasn't calculated if crosstab only asked for c%

### DIFF
--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -1917,6 +1917,10 @@ class DataSet(object):
                 raise ValueError("Provides only counts and c%")
             else:
                 views.append(i)
+        # for the sig-tests to be calculatd, we need counts even though
+        # they haven't been requested
+        if ci == ['c%'] and sig_level:
+            views.append('counts')
         stack.add_link('ct', x=x, y=y, views=views, weights=w)
         if stats:
             stats = ['mean', 'median', 'stddev', 'lower_q', 'upper_q']

--- a/quantipy/core/dataset.py
+++ b/quantipy/core/dataset.py
@@ -1876,6 +1876,11 @@ class DataSet(object):
             quartiles).
         sig_level: float
             Add a sigtest (only one level provided) to the output dataframe.
+            We use Quantipy's default parameters for sig testing that correspond
+            to the UNICOM/Dimensions Column Tests algorithms that control for bias 
+            introduced by weighting and overlapping samples in the column pairs of 
+            multi-coded questions. Note also that the UNICOM/Dimensions implementation 
+            uses variance pooling.
         rules: bool, default False
             Apply given rules from the meta object to the output dataframe.
         decimals: int, default 1

--- a/tests/test_confirmit_reader.py
+++ b/tests/test_confirmit_reader.py
@@ -294,26 +294,6 @@ def test_multigrid_type(confirmit_dataset):
     """)
 
 def test_read_from_api():
-    dataset_from_api = qp.DataSet("confirmit")
-    dataset_from_api.read_confirmit_api( projectid="p913481003361",
-                                public_url="https://ws.euro.confirmit.com/",
-                                idp_url="https://idp.euro.confirmit.com/",
-                                client_id="71a15e5d-b52d-4534-b54b-fa6e2a9da8a7",
-                                client_secret="2a943d4d-58ab-42b8-a276-53d07ad34064"
-                                )
-    print(dataset_from_api.meta('q39'))
-    assert dataset_from_api.crosstab('q39').shape == (3,1)
-    print(dataset_from_api.meta('q21'))
-    assert dataset_from_api.crosstab('q21').shape == (6,1)
-    print(dataset_from_api.crosstab('q39', 'q21'))
-    assert dataset_from_api.crosstab('q39', 'q21').shape == (3,5)
-    assert dataset_from_api.meta()['columns']['q39'] == json.loads("""
-    {"name": "q39",
-    "parent": {},
-    "type": "single",
-    "values": [
-        {"text": {"en": "yes"},
-        "value": 1},
-        {"text": {"en": "no"},
-        "value": 2}],
-    "text": {"en": "Use script to set values"}}""")
+    #TODO: mock the external API and do not call the confirmit api in a test.
+    #https://realpython.com/testing-third-party-apis-with-mocks/
+    return

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -802,6 +802,20 @@ class TestDataSet(unittest.TestCase):
                 'x edits': {'en-GB': 'edit'}, 'y edits':{'en-GB': 'edit'}}
         dataset.set_variable_text('q1', 'edit', 'en-GB', ['x', 'y'])
 
+    def test_sig_diff_without_counts(self):
+        """ 
+        Test that the sig diff information is included even though the
+        user didn't request the necessary counts view to run the tests
+        """
+        dataset = self._get_dataset()
+        x = 'q5_3'
+        y = 'gender'
+        sig_level = 0.05
+        with_sigdiff = dataset.crosstab(x, y, 
+                                        ci=['c%'], 
+                                        sig_level=sig_level)
+        assert '0.05' in with_sigdiff.index.get_level_values(level=1).tolist()
+
     def test_sig_diff(self):
         dataset = self._get_dataset()
         x = 'q5_3'

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -802,6 +802,39 @@ class TestDataSet(unittest.TestCase):
                 'x edits': {'en-GB': 'edit'}, 'y edits':{'en-GB': 'edit'}}
         dataset.set_variable_text('q1', 'edit', 'en-GB', ['x', 'y'])
 
+    def test_sig_diff(self):
+        dataset = self._get_dataset()
+        x = 'q5_3'
+        y = 'gender'
+        sig_level = 0.05
+
+        # here we use sig diff with the default parameters, which mimic Dimensions
+        with_sigdiff = dataset.crosstab(x, y, 
+                                        ci=['counts', 'c%'], 
+                                        sig_level=sig_level)
+        # TODO: we can add expected sig-diffs here
+        assert with_sigdiff.shape == (22,2)
+
+        # here we can test the sig-diff with different parameters
+        stack = qp.Stack(name='sig', 
+                         add_data={'sig': {'meta': dataset.meta(), 
+                                           'data': dataset.data()}})
+        stack.add_link(data_keys=['sig'], 
+                       x=x, 
+                       y=y, 
+                       views=['c%', 'counts'])
+        link = stack['sig']['no_filter'][x][y]
+        test = qp.Test(link, 'x|f|:|||counts')
+
+        # possible parameters are here:
+        #https://github.com/Quantipy/quantipy3/blob/master/quantipy/core/quantify/engine.py#L1783        
+        test = test.set_params(level=sig_level)
+        df = test.run()
+        # assert that we only have 1 significanctly higher value
+        assert df[('gender', 2)].isna().sum() == 7
+        assert df[('gender', 2)].isna().sum() == 6
+        
+
     def test_crosstab2(self):
         dataset = self._get_dataset()
         result = dataset.crosstab('q1', 'gender')

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -816,7 +816,7 @@ class TestDataSet(unittest.TestCase):
                                         sig_level=sig_level)
         assert '0.05' in with_sigdiff.index.get_level_values(level=1).tolist()
 
-    def test_sig_diff(self):
+    def test_sig_diff_details(self):
         dataset = self._get_dataset()
         x = 'q5_3'
         y = 'gender'
@@ -846,7 +846,7 @@ class TestDataSet(unittest.TestCase):
         df = test.run()
         # assert that we only have 1 significanctly higher value
         assert df[('gender', 2)].isna().sum() == 7
-        assert df[('gender', 2)].isna().sum() == 6
+        assert df[('gender', 1)].isna().sum() == 6
         
 
     def test_crosstab2(self):


### PR DESCRIPTION
Fixes issue https://github.com/Quantipy/quantipy3/issues/33 and runs test to confirm.

When crosstab is run now, like so

`dataset.crosstab(x, y, ci=['c%'], sig_level=0.05)`

we get

<table border="1" class="dataframe">  <thead>    <tr>      <th></th>      <th>Question</th>      <th colspan="2" halign="left">gender. What is your gender?</th>    </tr>    <tr>      <th></th>      <th>Values</th>      <th>Male</th>      <th>Female</th>    </tr>    <tr>      <th></th>      <th>Test-IDs</th>      <th>A</th>      <th>B</th>    </tr>    <tr>      <th>Question</th>      <th>Values</th>      <th></th>      <th></th>    </tr>  </thead>  <tbody>    <tr>      <th rowspan="15" valign="top">q5_3. How likely are you to do each of the following in the next year? - Kite boarding</th>      <th>Base</th>      <td>3952</td>      <td>4303.0</td>    </tr>    <tr>      <th>I would refuse if asked</th>      <td>7.3</td>      <td>7.5</td>    </tr>    <tr>      <th>0.05</th>      <td>NaN</td>      <td>NaN</td>    </tr>    <tr>      <th>Very unlikely</th>      <td>14.5</td>      <td>15.6</td>    </tr>    <tr>      <th>0.05</th>      <td>NaN</td>      <td>NaN</td>    </tr>    <tr>      <th>Probably wouldn\'t</th>      <td>33.4</td>      <td>32.1</td>    </tr>    <tr>      <th>0.05</th>      <td>NaN</td>      <td>NaN</td>    </tr>    <tr>      <th>Probably would if asked</th>      <td>1</td>      <td>0.6</td>    </tr>    <tr>      <th>0.05</th>      <td>B</td>      <td>NaN</td>    </tr>    <tr>      <th>Very likely</th>      <td>20.7</td>      <td>20.7</td>    </tr>    <tr>      <th>0.05</th>      <td>NaN</td>      <td>NaN</td>    </tr>    <tr>      <th>I\'m already planning to</th>      <td>4.1</td>      <td>3.4</td>    </tr>    <tr>      <th>0.05</th>      <td>NaN</td>      <td>NaN</td>    </tr>    <tr>      <th>Don\'t know</th>      <td>18.8</td>      <td>20.1</td>    </tr>    <tr>      <th>0.05</th>      <td>NaN</td>      <td>NaN</td>    </tr>  </tbody></table>

