### PR TITLE
Fix reading of native SPSS multichoice variables 

### DIFF
--- a/quantipy/core/tools/dp/spss/reader.py
+++ b/quantipy/core/tools/dp/spss/reader.py
@@ -165,7 +165,7 @@ def extract_sav_meta(sav_file, name="", data=None, ioLocale='en_US.UTF-8',
         # meta['masks'][mrset] = {}
         # 'D' is "multiple dichotomy sets" in SPSS
         # 'C' is "multiple category sets" in SPSS
-        varNames = metadata.multRespDefs[mrset]['varNames']
+        varNames = list(metadata.multRespDefs[mrset]['varNames'])
         # Find the index where there delimited set should be inserted
         # into data, which is immediately prior to the start of the
         # dichotomous set columns

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -40,6 +40,11 @@ class TestDataSet(unittest.TestCase):
         dataset = self._get_dataset()
         self.assertTrue(isinstance(dataset._data, pd.DataFrame))
         self.assertTrue(isinstance(dataset._meta, dict))
+        
+    def test_read_spss(self):
+        dataset = qp.DataSet('spss')
+        dataset.read_spss('tests/Example Data (A) - with multi choice q2.sav')
+        self.assertTrue(dataset.meta('q2').shape == (8,3))
 
     def test_fileinfo(self):
         dataset = self._get_dataset()


### PR DESCRIPTION
This was failing since the conversion to python3, because we need to cast a map to a list before we can reference its elements.