### PR TITLE
Support readstats for sav files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ docs/API/_templates/
 .eggs/
 .cache
 .pytest_cache/*
+.mypy_cache/*
 build

--- a/quantipy/core/tools/dp/spss/reader.py
+++ b/quantipy/core/tools/dp/spss/reader.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-from pandas.core.base import PandasObject
 import savReaderWriter as sr
 import pyreadstat
 

--- a/quantipy/core/tools/dp/spss/reader.py
+++ b/quantipy/core/tools/dp/spss/reader.py
@@ -1,13 +1,15 @@
 import numpy as np
 import pandas as pd
+from pandas.core.base import PandasObject
 import savReaderWriter as sr
+import pyreadstat
 
 from collections import defaultdict
 from quantipy.core.tools.dp.prep import start_meta, condense_dichotomous_set
 import os
 
 def parse_sav_file(filename, path=None, name="", ioLocale="en_US.UTF-8", ioUtf8=True, dichot=None,
-                   dates_as_strings=False, text_key="en-GB"):
+                   dates_as_strings=False, text_key="en-GB", engine='savReaderWriter'):
     """ Parses a .sav file and returns a touple of Data and Meta
 
         Parameters
@@ -33,188 +35,239 @@ dates_as_strings : bool, default=False
     """
     filepath="{}{}".format(path or '', filename)
     filepath = os.path.abspath(filepath)
-    data = extract_sav_data(filepath, ioLocale=ioLocale, ioUtf8=ioUtf8)
+    data = extract_sav_data(filepath, ioLocale=ioLocale, ioUtf8=ioUtf8, engine=engine)
     meta, data = extract_sav_meta(filepath, name="", data=data, ioLocale=ioLocale,
                                   ioUtf8=ioUtf8, dichot=dichot, dates_as_strings=dates_as_strings,
-                                  text_key=text_key)
+                                  text_key=text_key, engine=engine)
     return (meta, data)
 
-def extract_sav_data(sav_file, ioLocale='en_US.UTF-8', ioUtf8=True):
+def extract_sav_data(sav_file, ioLocale='en_US.UTF-8', ioUtf8=True, engine='savReaderWriter'):
+
     """ see parse_sav_file doc """
-    with sr.SavReader(sav_file, returnHeader=True, ioLocale=ioLocale, ioUtf8=ioUtf8) as reader:
-        thedata = [x for x in reader]
-        header = thedata[0]
-        dataframe = pd.DataFrame.from_records(thedata[1:], coerce_float=False)
-        dataframe.columns = header
-        for column in header:
-            if isinstance(dataframe[column].dtype, np.object):
-                # Replace None with NaN because SRW returns None if casting dates fails (dates are of type np.object))
-                values = dataframe[column].dropna().values
-                if len(values) > 0:
-                    if isinstance(values[0], str):
-                        dataframe[column] = dataframe[column].dropna().map(str.strip)
-                    elif isinstance(values[0], str):
-                        # savReaderWriter casts dates to str
-                        dataframe[column] = dataframe[column].dropna().map(str.strip)
-                        # creating DATETIME objects should happen here
-        return dataframe
+    if engine == 'savReaderWriter':
+        with sr.SavReader(sav_file, returnHeader=True, ioLocale=ioLocale, ioUtf8=ioUtf8) as reader:
+            thedata = [x for x in reader]
+            header = thedata[0]
+            dataframe = pd.DataFrame.from_records(thedata[1:], coerce_float=False)
+            dataframe.columns = header
+            for column in header:
+                if isinstance(dataframe[column].dtype, np.object):
+                    # Replace None with NaN because SRW returns None if casting dates fails (dates are of type np.object))
+                    values = dataframe[column].dropna().values
+                    if len(values) > 0:
+                        if isinstance(values[0], str):
+                            dataframe[column] = dataframe[column].dropna().map(str.strip)
+                        elif isinstance(values[0], str):
+                            # savReaderWriter casts dates to str
+                            dataframe[column] = dataframe[column].dropna().map(str.strip)
+                            # creating DATETIME objects should happen here
+            return dataframe
+    elif engine == 'readstat':
+        df, meta = pyreadstat.read_sav(sav_file)
+        return df
 
 def extract_sav_meta(sav_file, name="", data=None, ioLocale='en_US.UTF-8',
                      ioUtf8=True, dichot=None, dates_as_strings=False,
-                     text_key="en-GB"):
+                     text_key="en-GB", engine='savReaderWriter'):
 
-    if dichot is None: dichot = {'yes': 1, 'no': 0}
+    if engine == 'readstat':
+        df, metadata = pyreadstat.read_sav(sav_file, encoding=ioLocale.split(".")[-1], metadataonly=True)
+        meta = start_meta(text_key=text_key)
 
-    """ see parse_sav_file doc """
-    with sr.SavHeaderReader(sav_file, ioLocale=ioLocale, ioUtf8=ioUtf8) as header:
-        # Metadata Attributes
-        # ['valueLabels', 'varTypes', 'varSets', 'varAttributes', 'varRoles',
-        #  'measureLevels', 'caseWeightVar', 'varNames', 'varLabels', 'formats',
-        #  'multRespDefs', 'columnWidths', 'fileAttributes', 'alignments',
-        #  'fileLabel', 'missingValues']
-        metadata = header.dataDictionary(True)
+        meta['info']['text'] = 'Converted from SAV file {}.'.format(name)
+        meta['info']['from_source'] = {'pandas_reader':'sav'}
+        meta['sets']['data file']['items'] = [
+            'columns@{}'.format(varName)
+            for varName in metadata.column_names]
 
-    meta = start_meta(text_key=text_key)
-    meta['info']['text'] = 'Converted from SAV file {}.'.format(name)
-    meta['info']['from_source'] = {'pandas_reader':'sav'}
-    meta['sets']['data file']['items'] = [
-        'columns@{}'.format(varName)
-        for varName in metadata.varNames]
-
-    # This should probably be somewhere in the metadata
-    # weight_variable_name = metadata.caseWeightVar
-
-    # Descriptions of attributes in metadata are are located here :
-    # http://pythonhosted.org/savReaderWriter/#savwriter-write-spss-system-files
-    for column in metadata.varNames:
-        meta['columns'][column] = {}
-        meta['columns'][column]['name'] = column
-        meta['columns'][column]['parent'] = {}
-        if column in metadata.valueLabels:
-            # ValueLabels is type = 'single' (possibry 1-1 map)
-            meta['columns'][column]['values'] = []
-            meta['columns'][column]['type'] = "single"
-            for value, text in metadata.valueLabels[column].items():
-                values = {'text': {text_key: str(text)},
-                          'value': int(value)}
-                meta['columns'][column]['values'].append(values)
-        else:
-            if column in metadata.formats:
-                f = metadata.formats[column]
-                if 'DATETIME' in f:
-                    if dates_as_strings:
-                        # DATETIME fields from SPSS are currently
-                        # being read in as strings because there's an
-                        # as-yet undetermined discrepancy between the
-                        # input and output dates if datetime64 is used
-                        meta['columns'][column]['type'] = 'string'
-                    else:
-                        meta['columns'][column]['type'] = 'date'
-                        data[column] = pd.to_datetime(data[column])
-                elif f.startswith('A'):
-                    meta['columns'][column]['type'] = 'string'
-                elif '.' in f:
-                    meta['columns'][column]['type'] = "float"
-                else:
-                    meta['columns'][column]['type'] = "int"
+        for index, column in enumerate(metadata.column_names):
+            meta['columns'][column] = {}
+            meta['columns'][column]['name'] = column
+            meta['columns'][column]['parent'] = {}
+            if column in metadata.variable_value_labels:
+                meta['columns'][column]['values'] = []
+                meta['columns'][column]['type'] = "single"
+                for value, text in metadata.variable_value_labels[column].items():
+                    values = {'text': {text_key: str(text)},
+                            'value': int(value)}
+                    meta['columns'][column]['values'].append(values)
             else:
-                # Infer meta from data
-                if data is not None:
-                    # print "VAR '{}' NOT IN value_labels".format(column)
-                    column_values = data[column].dropna()
-                    if len(column_values) > 0:
-                        # Get the first "not nan" value from the column
-                        value = column_values.values[0]
-                        if isinstance(value, pd.np.float64):
-                            # Float AND Int because savReaderWriter loads them both as float64
-                            meta['columns'][column]['text'] = {text_key: [column]}
-                            meta['columns'][column]['type'] = "float"
-                            if (data[column].dropna() % 1).sum() == 0:
-                                if (data[column].dropna() % 1).unique() == [0]:
-                                    try:
-                                        data[column] = data[column].astype('int')
-                                    except:
-                                        pass
-                                    meta['columns'][column]['type'] = "int"
+                if column in metadata.original_variable_types:
+                    f = metadata.original_variable_types[column]
+                    if 'DATETIME' in f:
+                        if dates_as_strings:
+                            # DATETIME fields from SPSS are currently
+                            # being read in as strings because there's an
+                            # as-yet undetermined discrepancy between the
+                            # input and output dates if datetime64 is used
+                            meta['columns'][column]['type'] = 'string'
+                        else:
+                            meta['columns'][column]['type'] = 'date'
+                            data[column] = pd.to_datetime(data[column])
+                    elif f.startswith('A'):
+                        meta['columns'][column]['type'] = 'string'
+                    elif '.' in f:
+                        meta['columns'][column]['type'] = "float"
+                    else:
+                        meta['columns'][column]['type'] = "int"
 
-                        elif isinstance(value, str) or isinstance(value, str):
-                            # Strings
-                            meta['columns'][column]['text'] = {text_key: [column]}
-                            meta['columns'][column]['type'] = "string"
+            # add the variable label to the meta
+            meta['columns'][column]['text'] = {text_key : metadata.column_labels[index]}    
+        return meta, data
 
-        if column in metadata.varTypes:
-            pass
+    elif engine == 'savReaderWriter':
+        if dichot is None: dichot = {'yes': 1, 'no': 0}
 
-        if column in metadata.varSets:
-            pass
+        """ see parse_sav_file doc """
+        with sr.SavHeaderReader(sav_file, ioLocale=ioLocale, ioUtf8=ioUtf8) as header:
+            # Metadata Attributes
+            # ['valueLabels', 'varTypes', 'varSets', 'varAttributes', 'varRoles',
+            #  'measureLevels', 'caseWeightVar', 'varNames', 'varLabels', 'formats',
+            #  'multRespDefs', 'columnWidths', 'fileAttributes', 'alignments',
+            #  'fileLabel', 'missingValues']
+            metadata = header.dataDictionary(True)
 
-        if column in metadata.varAttributes:
-            pass
+        meta = start_meta(text_key=text_key)
+        meta['info']['text'] = 'Converted from SAV file {}.'.format(name)
+        meta['info']['from_source'] = {'pandas_reader':'sav'}
+        meta['sets']['data file']['items'] = [
+            'columns@{}'.format(varName)
+            for varName in metadata.varNames]
 
-        if column in metadata.varRoles:
-            pass
+        # This should probably be somewhere in the metadata
+        # weight_variable_name = metadata.caseWeightVar
 
-        if column in metadata.measureLevels:
-            pass
+        # Descriptions of attributes in metadata are are located here :
+        # http://pythonhosted.org/savReaderWriter/#savwriter-write-spss-system-files
+        for column in metadata.varNames:
+            meta['columns'][column] = {}
+            meta['columns'][column]['name'] = column
+            meta['columns'][column]['parent'] = {}
+            if column in metadata.valueLabels:
+                # ValueLabels is type = 'single' (possibry 1-1 map)
+                meta['columns'][column]['values'] = []
+                meta['columns'][column]['type'] = "single"
+                for value, text in metadata.valueLabels[column].items():
+                    values = {'text': {text_key: str(text)},
+                            'value': int(value)}
+                    meta['columns'][column]['values'].append(values)
+            else:
+                if column in metadata.formats:
+                    f = metadata.formats[column]
+                    if 'DATETIME' in f:
+                        if dates_as_strings:
+                            # DATETIME fields from SPSS are currently
+                            # being read in as strings because there's an
+                            # as-yet undetermined discrepancy between the
+                            # input and output dates if datetime64 is used
+                            meta['columns'][column]['type'] = 'string'
+                        else:
+                            meta['columns'][column]['type'] = 'date'
+                            data[column] = pd.to_datetime(data[column])
+                    elif f.startswith('A'):
+                        meta['columns'][column]['type'] = 'string'
+                    elif '.' in f:
+                        meta['columns'][column]['type'] = "float"
+                    else:
+                        meta['columns'][column]['type'] = "int"
+                else:
+                    # Infer meta from data
+                    if data is not None:
+                        # print "VAR '{}' NOT IN value_labels".format(column)
+                        column_values = data[column].dropna()
+                        if len(column_values) > 0:
+                            # Get the first "not nan" value from the column
+                            value = column_values.values[0]
+                            if isinstance(value, pd.np.float64):
+                                # Float AND Int because savReaderWriter loads them both as float64
+                                meta['columns'][column]['text'] = {text_key: [column]}
+                                meta['columns'][column]['type'] = "float"
+                                if (data[column].dropna() % 1).sum() == 0:
+                                    if (data[column].dropna() % 1).unique() == [0]:
+                                        try:
+                                            data[column] = data[column].astype('int')
+                                        except:
+                                            pass
+                                        meta['columns'][column]['type'] = "int"
 
-        # Some labels are empty strings.
-        if column in metadata.varLabels:
-            meta['columns'][column]['text'] = {text_key: metadata.varLabels[column]}
+                            elif isinstance(value, str) or isinstance(value, str):
+                                # Strings
+                                meta['columns'][column]['text'] = {text_key: [column]}
+                                meta['columns'][column]['type'] = "string"
 
-    for mrset in metadata.multRespDefs:
-        # meta['masks'][mrset] = {}
-        # 'D' is "multiple dichotomy sets" in SPSS
-        # 'C' is "multiple category sets" in SPSS
-        varNames = list(metadata.multRespDefs[mrset]['varNames'])
-        # Find the index where there delimited set should be inserted
-        # into data, which is immediately prior to the start of the
-        # dichotomous set columns
-        dls_idx = data.columns.tolist().index(varNames[0])
-        if metadata.multRespDefs[mrset]['setType'] == 'C':
-            # Raise if value object of columns is not equal
-            if not all(meta['columns'][v]['values'] == meta['columns'][varNames[0]]['values']
-                       for v in varNames):
-                msg = 'Columns must have equal values to be combined in a set: {}'
-                raise ValueError(msg.format(varNames))
-            # Concatenate columns to set
-            df_str = data[varNames].astype('str')
-            dls = df_str.apply(lambda x: ';'.join([
-                v.replace('.0', '') for v in x.tolist()
-                if not v in ['nan', 'None']]),
-                axis=1) + ';'
-            dls.replace({';': np.NaN}, inplace=True)
-            # Get value object
-            values = meta['columns'][varNames[0]]['values']
+            if column in metadata.varTypes:
+                pass
 
-        elif metadata.multRespDefs[mrset]['setType'] == 'D':
-            # Generate the delimited set from the dichotomous set
-            dls = condense_dichotomous_set(data[varNames], values_from_labels=False, **dichot)
-            # Get value object
-            values = [{
-                        'text': {text_key: metadata.varLabels[varName]},
-                        'value': int(v)
-                    }
-                    for v, varName in enumerate(varNames, start=1)]
-        else:
-            continue
-        # Insert the delimited set into data
-        data.insert(dls_idx, mrset, dls)
-        # Generate the column meta for the new delimited set
-        meta['columns'][mrset] = {
-            'name': mrset,
-            'type': 'delimited set',
-            'text': {text_key: metadata.multRespDefs[mrset]['label']},
-            'parent': {},
-            'values': values}
-        # Add the new delimited set to the 'data file' set
-        df_items = meta['sets']['data file']['items']
-        df_items.insert(
-            df_items.index('columns@{}'.format(varNames[0])),
-            'columns@{}'.format(mrset))
+            if column in metadata.varSets:
+                pass
 
-        data = data.drop(varNames, axis=1)
-        for varName in varNames:
-            df_items.remove('columns@{}'.format(varName))
-            del meta['columns'][varName]
+            if column in metadata.varAttributes:
+                pass
 
-    return meta, data
+            if column in metadata.varRoles:
+                pass
+
+            if column in metadata.measureLevels:
+                pass
+
+            # Some labels are empty strings.note
+            if column in metadata.varLabels:
+                meta['columns'][column]['text'] = {text_key: metadata.varLabels[column]}
+
+        for mrset in metadata.multRespDefs:
+            # meta['masks'][mrset] = {}
+            # 'D' is "multiple dichotomy sets" in SPSS
+            # 'C' is "multiple category sets" in SPSS
+            varNames = list(metadata.multRespDefs[mrset]['varNames'])
+            # Find the index where there delimited set should be inserted
+            # into data, which is immediately prior to the start of the
+            # dichotomous set columns
+            dls_idx = data.columns.tolist().index(varNames[0])
+            if metadata.multRespDefs[mrset]['setType'] == 'C':
+                # Raise if value object of columns is not equal
+                if not all(meta['columns'][v]['values'] == meta['columns'][varNames[0]]['values']
+                        for v in varNames):
+                    msg = 'Columns must have equal values to be combined in a set: {}'
+                    raise ValueError(msg.format(varNames))
+                # Concatenate columns to set
+                df_str = data[varNames].astype('str')
+                dls = df_str.apply(lambda x: ';'.join([
+                    v.replace('.0', '') for v in x.tolist()
+                    if not v in ['nan', 'None']]),
+                    axis=1) + ';'
+                dls.replace({';': np.NaN}, inplace=True)
+                # Get value object
+                values = meta['columns'][varNames[0]]['values']
+
+            elif metadata.multRespDefs[mrset]['setType'] == 'D':
+                # Generate the delimited set from the dichotomous set
+                dls = condense_dichotomous_set(data[varNames], values_from_labels=False, **dichot)
+                # Get value object
+                values = [{
+                            'text': {text_key: metadata.varLabels[varName]},
+                            'value': int(v)
+                        }
+                        for v, varName in enumerate(varNames, start=1)]
+            else:
+                continue
+            # Insert the delimited set into data
+            data.insert(dls_idx, mrset, dls)
+            # Generate the column meta for the new delimited set
+            meta['columns'][mrset] = {
+                'name': mrset,
+                'type': 'delimited set',
+                'text': {text_key: metadata.multRespDefs[mrset]['label']},
+                'parent': {},
+                'values': values}
+            # Add the new delimited set to the 'data file' set
+            df_items = meta['sets']['data file']['items']
+            df_items.insert(
+                df_items.index('columns@{}'.format(varNames[0])),
+                'columns@{}'.format(mrset))
+
+            data = data.drop(varNames, axis=1)
+            for varName in varNames:
+                df_items.remove('columns@{}'.format(varName))
+                del meta['columns'][varName]
+
+        return meta, data

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ decorator
 watchdog
 requests
 python-pptx
+pyreadstat

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ libs = ['numpy',
         'decorator',
         'watchdog',
         'requests',
-        'python-pptx']
+        'python-pptx',
+        'pyreadstat']
 
 def version_libs(libs, precisions, versions):
     return [lib + precisions[lib] + versions[lib]
@@ -38,7 +39,7 @@ else:
     INSTALL_REQUIRES = version_libs(libs, precisions, versions)
 
 setup(name='quantipy3',
-      version='0.2.6',
+      version='0.2.7',
       author='Geir Freysson',
       author_email='geir@datasmoothie.com',
       packages=find_packages(exclude=['tests']),

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -834,26 +834,26 @@ class TestDataSet(unittest.TestCase):
 
     def test_sig_diff_details(self):
         dataset = self._get_dataset()
-        x = 'weight_a'
+        x = 'q5_3'
         y = 'gender'
         sig_level = 0.05
 
         # here we use sig diff with the default parameters, which mimic Dimensions
         with_sigdiff = dataset.crosstab(x, y, 
                                         ci=['counts', 'c%'], 
-                                        sig_level=sig_level,
-                                        stats=True)
+                                        sig_level=sig_level)
         # TODO: we can add expected sig-diffs here
-        import pdb; pdb.set_trace()
-        #assert with_sigdiff.shape == (22,2)
+        assert with_sigdiff.shape == (22,2)
 
         # here we can test the sig-diff with different parameters
         stack = qp.Stack(name='sig', 
                          add_data={'sig': {'meta': dataset.meta(), 
                                            'data': dataset.data()}})
-        stack.add_link(data_keys=['sig'], x=x, y=y, views=['c%', 'counts', 'means'])
+        stack.add_link(data_keys=['sig'], 
+                       x=x, 
+                       y=y, 
+                       views=['c%', 'counts'])
         link = stack['sig']['no_filter'][x][y]
-        import pdb; pdb.set_trace()
         test = qp.Test(link, 'x|f|:|||counts')
 
         # possible parameters are here:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -46,6 +46,17 @@ class TestDataSet(unittest.TestCase):
         dataset.read_spss('tests/Example Data (A) - with multi choice q2.sav')
         self.assertTrue(dataset.meta('q2').shape == (8,3))
 
+    def test_read_spss_readstat(self):
+        dataset_v1 = qp.DataSet('spss')
+        dataset_v1.read_spss('tests/Example Data (A) - with multi choice q2.sav')
+        dataset = qp.DataSet('spss')
+        dataset.read_spss('tests/Example Data (A) - with multi choice q2.sav', engine='readstat')
+        # the label of the set is lost as this engine doesn't support delimited sets
+        dataset.to_delimited_set('q2', dataset_v1.text('q2'), dataset.find('q2_'))
+        self.assertTrue(dataset.meta('q2').shape == (8,3))
+        assert dataset.crosstab('q2').equals(dataset_v1.crosstab('q2'))        
+        assert dataset.crosstab('q2b').equals(dataset_v1.crosstab('q2b'))
+
     def test_fileinfo(self):
         dataset = self._get_dataset()
         meta_def_key =  dataset._meta['lib']['default text']
@@ -823,26 +834,26 @@ class TestDataSet(unittest.TestCase):
 
     def test_sig_diff_details(self):
         dataset = self._get_dataset()
-        x = 'q5_3'
+        x = 'weight_a'
         y = 'gender'
         sig_level = 0.05
 
         # here we use sig diff with the default parameters, which mimic Dimensions
         with_sigdiff = dataset.crosstab(x, y, 
                                         ci=['counts', 'c%'], 
-                                        sig_level=sig_level)
+                                        sig_level=sig_level,
+                                        stats=True)
         # TODO: we can add expected sig-diffs here
-        assert with_sigdiff.shape == (22,2)
+        import pdb; pdb.set_trace()
+        #assert with_sigdiff.shape == (22,2)
 
         # here we can test the sig-diff with different parameters
         stack = qp.Stack(name='sig', 
                          add_data={'sig': {'meta': dataset.meta(), 
                                            'data': dataset.data()}})
-        stack.add_link(data_keys=['sig'], 
-                       x=x, 
-                       y=y, 
-                       views=['c%', 'counts'])
+        stack.add_link(data_keys=['sig'], x=x, y=y, views=['c%', 'counts', 'means'])
         link = stack['sig']['no_filter'][x][y]
+        import pdb; pdb.set_trace()
         test = qp.Test(link, 'x|f|:|||counts')
 
         # possible parameters are here:


### PR DESCRIPTION
Add the option "engine" to sav reading. This means we can use the pyreadstat to read SPSS files and meta data.

Pros:
Faster 
More robust (won't fail under certain circumstances savReaderWriter fails)
Easier to use on multiple platforms

Cons:
Doesn't support SPSS sets (delimited sets) so users will have to create them afterwards (only one line of code)