### PR TITLE
Fix readstat if single stored as string

### DIFF
--- a/quantipy/core/tools/dp/spss/reader.py
+++ b/quantipy/core/tools/dp/spss/reader.py
@@ -90,6 +90,10 @@ def extract_sav_meta(sav_file, name="", data=None, ioLocale='en_US.UTF-8',
                     values = {'text': {text_key: str(text)},
                             'value': int(value)}
                     meta['columns'][column]['values'].append(values)
+                    # if user has stored single answer data as a string rather than number
+                    # we convert it to floats and store non convertables as nan (with coerce)
+                    if column in data.columns and data[column].dtype == 'O':
+                        data[column] = pd.to_numeric(data[column], errors='coerce', downcast='float')
             else:
                 if column in metadata.original_variable_types:
                     f = metadata.original_variable_types[column]

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ else:
     INSTALL_REQUIRES = version_libs(libs, precisions, versions)
 
 setup(name='quantipy3',
-      version='0.2.8',
+      version='0.2.9',
       author='Geir Freysson',
       author_email='geir@datasmoothie.com',
       packages=find_packages(exclude=['tests']),


### PR DESCRIPTION
Some users/software packages set value labels in SPSS (e.g. Urban=1, Rural=2) but store the codes, 1 and 2, as strings instead of numbers.

When using readstat we now check whether data is stored as an object for single response variables and if so, convert it to a float. 